### PR TITLE
CI: Use fixed revision of default packages for syntax tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,11 +3,13 @@ name: Syntax Tests
 on:
   push:
     paths:
+      - '.github/workflows/main.yml'
       - '**.sublime-syntax'
       - '**/syntax_test*'
       - '**.tmPreferences'
   pull_request:
     paths:
+      - '.github/workflows/main.yml'
       - '**.sublime-syntax'
       - '**/syntax_test*'
       - '**.tmPreferences'
@@ -21,5 +23,5 @@ jobs:
       - uses: SublimeText/syntax-test-action@v2
         with:
           build: 4113
-          default_packages: master
+          default_packages: v4113
           package_name: ElixirSyntax


### PR DESCRIPTION
Default packages should probably match the used ST test binary. Relevant tags are typically added to Packages repo.

It may also be a good idea to trigger syntax tests in case of the workflow definition file is updated.